### PR TITLE
bugfix events_in_future error in xmltv_parser

### DIFF
--- a/src/common/xmltv/xmltv_parser.c
+++ b/src/common/xmltv/xmltv_parser.c
@@ -188,7 +188,7 @@ static void xmltv_parser_add_event ()
 		if (current_desc)
 			epgdb_titles_set_long_description (title, current_desc);
 
-		if (current_starttime>=current_title)
+		if (current_starttime>=current_time)
 			events_in_future_count++;
 	}
 


### PR DESCRIPTION
With this bug crossepg produces an error that it believes there are no events in future. This error leads to the problem that crossepg downloads the xmltv files from every provided url instead of breaking the loop after already adding events for the first url